### PR TITLE
Tidy README and remove empty module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
+[![Build Status](https://travis-ci.org/bcoop713/moonsugar.svg?branch=master)](https://travis-ci.org/bcoop713/moonsugar)
+
 # Moonsugar
 
-**TODO: Add description**
+Addictive utility functions for elixir style data structures.
+
+ - `Moonsugar.Maybe`
+ - `Moonsugar.Result`
+ - `Moonsugar.Validation`
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `moonsugar` to your list of dependencies in `mix.exs`:
+The package can be installed by adding `moonsugar` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:moonsugar, "~> 0.1.0"}
+    {:moonsugar, "~> 0.1.2"}
   ]
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/moonsugar](https://hexdocs.pm/moonsugar).
-
+The docs can be found at [https://hexdocs.pm/moonsugar](https://hexdocs.pm/moonsugar).

--- a/lib/moonsugar.ex
+++ b/lib/moonsugar.ex
@@ -1,2 +1,0 @@
-defmodule Moonsugar do
-end

--- a/mix.exs
+++ b/mix.exs
@@ -1,10 +1,13 @@
 defmodule Moonsugar.MixProject do
   use Mix.Project
 
+  @version "0.1.2"
+  @github "https://github.com/bcoop713/moonsugar"
+
   def project do
     [
       app: :moonsugar,
-      version: "0.1.2",
+      version: @version,
       elixir: "~> 1.5",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -13,9 +16,14 @@ defmodule Moonsugar.MixProject do
         name: "moonsugar",
         licenses: ["MIT"],
         maintainers: ["bcoop713@gmail.com"],
-        links: %{"Github" => "https://github.com/bcoop713/moonsugar"}
+        links: %{"Github" => @github}
+      ],
+      docs: [
+        extras: ["README.md"],
+        main: "readme",
+        source_ref: "#{@version}",
+        source_url: @github
       ]
-
     ]
   end
 

--- a/test/moonsugar_test.exs
+++ b/test/moonsugar_test.exs
@@ -1,2 +1,0 @@
-defmodule MoonsugarTest do
-end


### PR DESCRIPTION
This PR adds just a little polish to the README/docs.

 - Add a travis badge
 - Add a description
 - Include README in page in docs
 - Link docs to the source (expects the release to be tagged in git as 0.1.2)
 - Remove empty `Moonsugar` module